### PR TITLE
Allow multiple blocks, and allow type in blocks.

### DIFF
--- a/changelog/release_notes.go
+++ b/changelog/release_notes.go
@@ -56,7 +56,10 @@ type ReleaseNote struct {
 	Type string
 }
 
-type releaseNoteEntry struct {
+// ReleaseNoteEntry is a struct containing the type of entry and the body of
+// the entry. One or more ReleaseNoteEntry is extracted from a PR, and
+// represents a single item within the release notes.
+type ReleaseNoteEntry struct {
 	Type string
 	Text string
 }
@@ -247,7 +250,7 @@ func pullRequestsToReleaseNotes(
 			}
 		}
 
-		for _, entry := range releaseNoteBlocks(n.PullRequest.Title, n.PullRequest.Body) {
+		for _, entry := range ReleaseNoteBlocks(n.PullRequest.Title, n.PullRequest.Body) {
 			n := note
 			n.Text = entry.Text
 			n.Type = entry.Type
@@ -265,8 +268,12 @@ var textInBodyREs = []*regexp.Regexp{
 	regexp.MustCompile("(?m)^```releasenote:(?P<type>[^\n]*)\n(?P<note>.+)\n```"),
 }
 
-func releaseNoteBlocks(title, body string) []releaseNoteEntry {
-	var res []releaseNoteEntry
+// ReleaseNoteBlocks accepts the PR title and body contents, and parses them
+// into one or more `ReleaseNoteEntry`s. It first attempts to find explicit
+// releasenote code blocks within the body, and failing that, falls back on
+// using the PR title as long as it is not empty.
+func ReleaseNoteBlocks(title, body string) []ReleaseNoteEntry {
+	var res []ReleaseNoteEntry
 	for _, re := range textInBodyREs {
 		matches := re.FindAllStringSubmatch(body, -1)
 		if len(matches) == 0 {
@@ -298,14 +305,14 @@ func releaseNoteBlocks(title, body string) []releaseNoteEntry {
 				continue
 			}
 
-			res = append(res, releaseNoteEntry{
+			res = append(res, ReleaseNoteEntry{
 				Type: typ,
 				Text: note,
 			})
 		}
 	}
 	if len(res) < 1 && title != "" {
-		res = append(res, releaseNoteEntry{
+		res = append(res, ReleaseNoteEntry{
 			Text: title,
 		})
 	}

--- a/changelog/release_notes.go
+++ b/changelog/release_notes.go
@@ -295,7 +295,6 @@ func ReleaseNoteBlocks(title, body string) []ReleaseNoteEntry {
 				}
 			}
 
-			note = strings.TrimRight(note, "\r")
 			note = stripMarkdownBullet(note)
 
 			note = strings.TrimSpace(note)

--- a/changelog/release_notes_test.go
+++ b/changelog/release_notes_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestTextFromPR(t *testing.T) {
 	for i, c := range []struct {
-		expected []releaseNoteEntry
+		expected []ReleaseNoteEntry
 		title    string
 		body     string
 	}{
@@ -18,22 +18,22 @@ func TestTextFromPR(t *testing.T) {
 		{nil, "", ""},
 
 		// text in title
-		{[]releaseNoteEntry{{Text: "foo"}}, "foo", ""},
+		{[]ReleaseNoteEntry{{Text: "foo"}}, "foo", ""},
 
 		// text in body, type in labels
-		{[]releaseNoteEntry{{Text: "foo"}}, "bar", "```release-note\nfoo\n```"},
-		{[]releaseNoteEntry{{Text: "foo"}}, "bar", "```releasenote\nfoo\n```"},
-		{[]releaseNoteEntry{{Text: "foo"}}, "bar", "\n```releasenote\nfoo\n```\n"},
+		{[]ReleaseNoteEntry{{Text: "foo"}}, "bar", "```release-note\nfoo\n```"},
+		{[]ReleaseNoteEntry{{Text: "foo"}}, "bar", "```releasenote\nfoo\n```"},
+		{[]ReleaseNoteEntry{{Text: "foo"}}, "bar", "\n```releasenote\nfoo\n```\n"},
 
 		// text in title (malformed body)
-		{[]releaseNoteEntry{{Text: "bar"}}, "bar", "\n ```releasenote\nfoo\n```"},
+		{[]ReleaseNoteEntry{{Text: "bar"}}, "bar", "\n ```releasenote\nfoo\n```"},
 
 		// text in body, type in body
-		{[]releaseNoteEntry{{Type: "bug", Text: "foo"}}, "", "```release-note:bug\nfoo\n```"},
-		{[]releaseNoteEntry{{Type: "enhancement", Text: "bar"}}, "", "```releasenote:enhancement\nbar\n```"},
+		{[]ReleaseNoteEntry{{Type: "bug", Text: "foo"}}, "", "```release-note:bug\nfoo\n```"},
+		{[]ReleaseNoteEntry{{Type: "enhancement", Text: "bar"}}, "", "```releasenote:enhancement\nbar\n```"},
 
 		// text in body, type in body, multiple blocks
-		{[]releaseNoteEntry{{Type: "bug", Text: "foo"}, {Type: "enhancement", Text: "bar"}},
+		{[]ReleaseNoteEntry{{Type: "bug", Text: "foo"}, {Type: "enhancement", Text: "bar"}},
 			"", "\n```releasenote:bug\nfoo\n```\n\n```release-note:enhancement\nbar\n```\n"},
 	} {
 		t.Run(fmt.Sprintf("%d %s", i, c.expected), func(t *testing.T) {
@@ -50,7 +50,7 @@ func TestTextFromPR(t *testing.T) {
 				}
 				return false
 			})
-			actual := releaseNoteBlocks(c.title, c.body)
+			actual := ReleaseNoteBlocks(c.title, c.body)
 			assert.Equal(t, res, actual)
 		})
 	}

--- a/changelog/release_notes_test.go
+++ b/changelog/release_notes_test.go
@@ -2,6 +2,7 @@ package changelog
 
 import (
 	"fmt"
+	"sort"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -9,27 +10,48 @@ import (
 
 func TestTextFromPR(t *testing.T) {
 	for i, c := range []struct {
-		expected string
+		expected []releaseNoteEntry
 		title    string
 		body     string
 	}{
 		// zero case
-		{"", "", ""},
+		{nil, "", ""},
 
 		// text in title
-		{"foo", "foo", ""},
+		{[]releaseNoteEntry{{Text: "foo"}}, "foo", ""},
 
-		// text in body
-		{"foo", "bar", "```release-note\nfoo\n```"},
-		{"foo", "bar", "```releasenote\nfoo\n```"},
-		{"foo", "bar", "\n```releasenote\nfoo\n```\n"},
+		// text in body, type in labels
+		{[]releaseNoteEntry{{Text: "foo"}}, "bar", "```release-note\nfoo\n```"},
+		{[]releaseNoteEntry{{Text: "foo"}}, "bar", "```releasenote\nfoo\n```"},
+		{[]releaseNoteEntry{{Text: "foo"}}, "bar", "\n```releasenote\nfoo\n```\n"},
 
 		// text in title (malformed body)
-		{"bar", "bar", "\n ```releasenote\nfoo\n```"},
+		{[]releaseNoteEntry{{Text: "bar"}}, "bar", "\n ```releasenote\nfoo\n```"},
+
+		// text in body, type in body
+		{[]releaseNoteEntry{{Type: "bug", Text: "foo"}}, "", "```release-note:bug\nfoo\n```"},
+		{[]releaseNoteEntry{{Type: "enhancement", Text: "bar"}}, "", "```releasenote:enhancement\nbar\n```"},
+
+		// text in body, type in body, multiple blocks
+		{[]releaseNoteEntry{{Type: "bug", Text: "foo"}, {Type: "enhancement", Text: "bar"}},
+			"", "\n```releasenote:bug\nfoo\n```\n\n```release-note:enhancement\nbar\n```\n"},
 	} {
 		t.Run(fmt.Sprintf("%d %s", i, c.expected), func(t *testing.T) {
-			actual := textFromPR(c.title, c.body)
-			assert.Equal(t, c.expected, actual)
+			res := c.expected
+			sort.Slice(res, func(i, j int) bool {
+				if res[i].Type < res[j].Type {
+					return true
+				} else if res[j].Type < res[i].Type {
+					return false
+				} else if res[i].Text < res[j].Text {
+					return true
+				} else if res[j].Text < res[i].Text {
+					return false
+				}
+				return false
+			})
+			actual := releaseNoteBlocks(c.title, c.body)
+			assert.Equal(t, res, actual)
 		})
 	}
 }

--- a/changelog/template.go
+++ b/changelog/template.go
@@ -54,6 +54,52 @@ BUGS
 {{- end -}}
 `
 
+const defaultBlockTypeChangelogTemplate = `
+{{- $breaking := newStringList -}}
+{{- $features := newStringList -}}
+{{- $improvements := newStringList -}}
+{{- $bugs := newStringList -}}
+{{- range . -}}
+  {{if eq "breaking-change" .Type -}}
+	{{$breaking = append $breaking (renderReleaseNote .) -}}
+  {{else if or (eq "new-resource" .Type) (eq "new-data-source" .Type) (eq "feature" .Type) -}}
+	{{$features = append $features (renderReleaseNote .) -}}
+  {{else if eq "improvement" .Type -}}
+	{{$improvements = append $improvements (renderReleaseNote .) -}}
+  {{else if eq "bug" .Type -}}
+	{{$bugs = append $bugs (renderReleaseNote .) -}}
+  {{end -}}
+{{- end -}}
+{{- if gt (len $breaking) 0 -}}
+BREAKING CHANGES
+
+{{range $breaking | sortAlpha -}}
+* {{. }}
+{{end -}}
+{{- end -}}
+{{- if gt (len $features) 0}}
+FEATURES
+
+{{range $features | sortAlpha -}}
+* {{. }}
+{{end -}}
+{{- end -}}
+{{- if gt (len $improvements) 0}}
+IMPROVEMENTS
+
+{{range $improvements | sortAlpha -}}
+* {{. }}
+{{end -}}
+{{- end -}}
+{{- if gt (len $bugs) 0}}
+BUGS
+
+{{range $bugs | sortAlpha -}}
+* {{. }}
+{{end -}}
+{{- end -}}
+`
+
 func filterPrefix(prefix string, trim bool, data []string) []string {
 	result := []string{}
 	for _, s := range data {

--- a/changelog/template.go
+++ b/changelog/template.go
@@ -54,52 +54,6 @@ BUGS
 {{- end -}}
 `
 
-const defaultBlockTypeChangelogTemplate = `
-{{- $breaking := newStringList -}}
-{{- $features := newStringList -}}
-{{- $improvements := newStringList -}}
-{{- $bugs := newStringList -}}
-{{- range . -}}
-  {{if eq "breaking-change" .Type -}}
-	{{$breaking = append $breaking (renderReleaseNote .) -}}
-  {{else if or (eq "new-resource" .Type) (eq "new-data-source" .Type) (eq "feature" .Type) -}}
-	{{$features = append $features (renderReleaseNote .) -}}
-  {{else if eq "improvement" .Type -}}
-	{{$improvements = append $improvements (renderReleaseNote .) -}}
-  {{else if eq "bug" .Type -}}
-	{{$bugs = append $bugs (renderReleaseNote .) -}}
-  {{end -}}
-{{- end -}}
-{{- if gt (len $breaking) 0 -}}
-BREAKING CHANGES
-
-{{range $breaking | sortAlpha -}}
-* {{. }}
-{{end -}}
-{{- end -}}
-{{- if gt (len $features) 0}}
-FEATURES
-
-{{range $features | sortAlpha -}}
-* {{. }}
-{{end -}}
-{{- end -}}
-{{- if gt (len $improvements) 0}}
-IMPROVEMENTS
-
-{{range $improvements | sortAlpha -}}
-* {{. }}
-{{end -}}
-{{- end -}}
-{{- if gt (len $bugs) 0}}
-BUGS
-
-{{range $bugs | sortAlpha -}}
-* {{. }}
-{{end -}}
-{{- end -}}
-`
-
 func filterPrefix(prefix string, trim bool, data []string) []string {
 	result := []string{}
 	for _, s := range data {

--- a/changelog/template_test.go
+++ b/changelog/template_test.go
@@ -57,6 +57,51 @@ BUGS
 	assert.Equal(t, expected, actual)
 }
 
+func TestRender_defaultBlockTypeChangelogTemplate(t *testing.T) {
+	expected := `BREAKING CHANGES
+
+* this is a breaking change ([0]() by []())
+
+FEATURES
+
+* this is a new data-source ([0]() by []())
+* this is a new resource ([0]() by []())
+
+IMPROVEMENTS
+
+* this is an improvement & 'stuff' ([0]() by []())
+
+BUGS
+
+* this is a bug ([0]() by []())
+`
+
+	actual, err := renderChangelog(defaultBlockTypeChangelogTemplate, defaultReleaseNoteTemplate, []ReleaseNote{
+		{
+			Type: "breaking-change",
+			Text: "this is a breaking change",
+		},
+		{
+			Type: "new-resource",
+			Text: "this is a new resource",
+		},
+		{
+			Type: "new-data-source",
+			Text: "this is a new data-source",
+		},
+		{
+			Type: "improvement",
+			Text: "this is an improvement & 'stuff'",
+		},
+		{
+			Type: "bug",
+			Text: "this is a bug",
+		},
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, expected, actual)
+}
+
 func TestRender_defaultReleaseNoteTemplate(t *testing.T) {
 	for i, c := range []struct {
 		expected string

--- a/changelog/template_test.go
+++ b/changelog/template_test.go
@@ -7,6 +7,52 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+const defaultBlockTypeChangelogTemplate = `
+{{- $breaking := newStringList -}}
+{{- $features := newStringList -}}
+{{- $improvements := newStringList -}}
+{{- $bugs := newStringList -}}
+{{- range . -}}
+  {{if eq "breaking-change" .Type -}}
+	{{$breaking = append $breaking (renderReleaseNote .) -}}
+  {{else if or (eq "new-resource" .Type) (eq "new-data-source" .Type) (eq "feature" .Type) -}}
+	{{$features = append $features (renderReleaseNote .) -}}
+  {{else if eq "improvement" .Type -}}
+	{{$improvements = append $improvements (renderReleaseNote .) -}}
+  {{else if eq "bug" .Type -}}
+	{{$bugs = append $bugs (renderReleaseNote .) -}}
+  {{end -}}
+{{- end -}}
+{{- if gt (len $breaking) 0 -}}
+BREAKING CHANGES
+
+{{range $breaking | sortAlpha -}}
+* {{. }}
+{{end -}}
+{{- end -}}
+{{- if gt (len $features) 0}}
+FEATURES
+
+{{range $features | sortAlpha -}}
+* {{. }}
+{{end -}}
+{{- end -}}
+{{- if gt (len $improvements) 0}}
+IMPROVEMENTS
+
+{{range $improvements | sortAlpha -}}
+* {{. }}
+{{end -}}
+{{- end -}}
+{{- if gt (len $bugs) 0}}
+BUGS
+
+{{range $bugs | sortAlpha -}}
+* {{. }}
+{{end -}}
+{{- end -}}
+`
+
 func TestRender_defaultChangelogTemplate(t *testing.T) {
 	expected := `BREAKING CHANGES
 


### PR DESCRIPTION
Add the ability to have multiple releasenote or release-note blocks
within a single PR, each generating their own ReleaseNote struct.

Also, add a Type field to the ReleaseNote struct, and let blocks have a
type embedded in them, like ```release-note:bug, which is then exposed
to templates via the Type field.