### PR TITLE
Allow empty blocks.

### DIFF
--- a/changelog/release_notes.go
+++ b/changelog/release_notes.go
@@ -261,10 +261,10 @@ func pullRequestsToReleaseNotes(
 }
 
 var textInBodyREs = []*regexp.Regexp{
-	regexp.MustCompile("(?m)^```release-note\n(?P<note>.+)\n```"),
-	regexp.MustCompile("(?m)^```releasenote\n(?P<note>.+)\n```"),
-	regexp.MustCompile("(?m)^```release-note:(?P<type>[^\n]*)\n(?P<note>.+)\n```"),
-	regexp.MustCompile("(?m)^```releasenote:(?P<type>[^\n]*)\n(?P<note>.+)\n```"),
+	regexp.MustCompile("(?m)^```release-note\n(?P<note>.*)\n?```"),
+	regexp.MustCompile("(?m)^```releasenote\n(?P<note>.*)\n?```"),
+	regexp.MustCompile("(?m)^```release-note:(?P<type>.*)\n?(?P<note>.*)\n?```"),
+	regexp.MustCompile("(?m)^```releasenote:(?P<type>.*)\n?(?P<note>.*)\n?```"),
 }
 
 // ReleaseNoteBlocks accepts the PR title and body contents, and parses them
@@ -299,7 +299,7 @@ func ReleaseNoteBlocks(title, body string) []ReleaseNoteEntry {
 			note = strings.TrimSpace(note)
 			typ = strings.TrimSpace(typ)
 
-			if note == "" {
+			if note == "" && typ == "" {
 				continue
 			}
 

--- a/changelog/release_notes_test.go
+++ b/changelog/release_notes_test.go
@@ -35,6 +35,16 @@ func TestTextFromPR(t *testing.T) {
 		// text in body, type in body, multiple blocks
 		{[]ReleaseNoteEntry{{Type: "bug", Text: "foo"}, {Type: "enhancement", Text: "bar"}},
 			"", "\n```releasenote:bug\nfoo\n```\n\n```release-note:enhancement\nbar\n```\n"},
+
+		// text in body, no note
+		{[]ReleaseNoteEntry{{Type: "none", Text: ""}}, "", "```release-note:none\n\n```"},
+		{[]ReleaseNoteEntry{{Type: "none", Text: ""}}, "", "```releasenote:none\n\n```"},
+		{[]ReleaseNoteEntry{{Type: "none", Text: ""}}, "", "```release-note:none\n```"},
+		{[]ReleaseNoteEntry{{Type: "none", Text: ""}}, "", "```releasenote:none\n```"},
+
+		// text in body, no type, no note
+		{nil, "", "```release-note\n\n```"},
+		{nil, "", "```release-note\n```"},
 	} {
 		t.Run(fmt.Sprintf("%d %s", i, c.expected), func(t *testing.T) {
 			res := c.expected


### PR DESCRIPTION
When using the markdown code block embedded in the PR body to supply a
changelog, we were discarding any blocks that were empty.

This prevents the use of a `release-note:none` empty block, which is
useful for signaling that you're intentionally not including a release
note for a PR, as it has no user-facing change.

This PR updates to add support for that, and a test to ensure it works
correctly.