### PR TITLE
Add option to exclude start commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ The following flags are supported:
 * **-changelog** Go template for changelog generation. The model is a slice of `ReleaseNote`.
 * **-releasenote** Go template for an individual release note. The model is a single `ReleaseNote`.
 * **-no-note-label** A label that indicates PRs should not create a release note. This option may be specified multiple times, once per each label. Defaults to `no-release-note` and `release-note-none`.
+* **-exclude-start** Exclude start commit from the generated changelog.
 
 In addition to flags you must also supply either 2 commit shas or 2 RFC3339 timestamps indicating the portion of the commit log to pull PRs for.
 

--- a/main.go
+++ b/main.go
@@ -29,6 +29,7 @@ type options struct {
 	changelogTemplate   string
 	releaseNoteTemplate string
 	noNoteLabels        []string
+	excludeStart        bool
 }
 
 func envString(key, def string) string {
@@ -89,6 +90,12 @@ func parseOptions(args []string) ([]string, *options, error) {
 			"",
 			"Release note template path (leave blank for built-in template)",
 		)
+
+		flExcludeStart = flagset.Bool(
+			"exclude-start",
+			false,
+			"Exclude start commit from changelog (defaults to false)",
+		)
 	)
 	flagset.Var(&flNoNoteLabel,
 		"no-note-label",
@@ -124,6 +131,7 @@ func parseOptions(args []string) ([]string, *options, error) {
 		changelogTemplate:   *flChangelogTemplate,
 		releaseNoteTemplate: *flReleaseNoteTemplate,
 		noNoteLabels:        []string(flNoNoteLabel),
+		excludeStart:        *flExcludeStart,
 	}, nil
 }
 
@@ -196,6 +204,10 @@ func main() {
 			if err != nil {
 				return err
 			}
+		}
+
+		if opts.excludeStart {
+			startTime = startTime.Add(time.Second)
 		}
 
 		endCommit, endTime, err := parseCommitOrTime(args[1])


### PR DESCRIPTION
This PR adds a flag `-exclude-start` to exclude start commit from the changelog. Defaults to `false` to keep current behaviour as default.

I find this a common scenario when changelog is generated current commit and the latest release (or master).
```
changelog-gen -owner <gh-owner> -repo <gh-repo> <latest_release_SHA> <current_SHA>
```
Without this flag, the `<latest_release_SHA>` commit, resp. Its associated PR, would be included in the generated changelog. However, this is undesirable, as that commit was already included in the previous release, and is not part of the current one.

I.e. because both start and end SHA intervals are closed, the start/end commits will be duplicated. This flag makes the start interval open, to avoid overlap.